### PR TITLE
Implementing user definable behaviour for resetting shuffle, repeat and crossfade

### DIFF
--- a/lib/__tests__/process_sonos_command.test.js
+++ b/lib/__tests__/process_sonos_command.test.js
@@ -43,8 +43,13 @@ describe('process_sonos_command', () => {
     },
     {
       service: 'TuneIn',
-      input: `tunein:${identifier}`,
-      expected_url: get_sonos_url(`tunein/now/tunein:${identifier}`, 'tunein'),
+      input: `${identifier}`,
+      expected_url: get_sonos_url(`${identifier}`, 'tunein'),
+    },
+    {
+      service: 'Favorite',
+      input: `${identifier}`,
+      expected_url: get_sonos_url(`${identifier}`, 'favorite'),
     },
     {
       service: 'Sonos Playlist',

--- a/lib/process_sonos_command.js
+++ b/lib/process_sonos_command.js
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import fs from 'fs';
 
-var { sonos_room, sonos_http_api, reset_shuffle, reset_repeat, reset_crossfade } = JSON.parse(
+var { sonos_room, sonos_http_api, reset_repeat, reset_shuffle, reset_crossfade } = JSON.parse(
   fs.readFileSync('usersettings.json', 'utf-8')
 );
 
@@ -29,9 +29,12 @@ export default async function process_sonos_command(received_text) {
   } else if (received_text_lower.startsWith('spotify:')) {
     service_type = 'spotify';
     sonos_instruction = 'spotify/now/' + received_text;
-  } else if (received_text_lower.startsWith('tunein:')) {
+  } else if (received_text_lower.startsWith('tunein/')) {
     service_type = 'tunein';
-    sonos_instruction = 'tunein/now/' + received_text;
+    sonos_instruction = received_text;
+  } else if (received_text_lower.startsWith('favorite/')) {
+    service_type = 'favorite';
+    sonos_instruction = received_text;
   } else if (received_text_lower.startsWith('amazonmusic:')) {
     service_type = 'amazonmusic';
     sonos_instruction = 'amazonmusic/now/' + received_text.slice(12);
@@ -58,42 +61,45 @@ export default async function process_sonos_command(received_text) {
   console.log("Detected '%s' service request", service_type);
 
   if (service_type != 'command') {
-    console.log(
-      'Resetting Sonos queue (clear, turn off repeat, shuffle, crossfade as per usersettings.json)'
-    );
     let res;
-    if (reset_repeat == true) {
-      console.log('Resetting repeat setting');
-      res = await fetch(get_sonos_url('repeat/off'));
-      if (!res.ok) {
+    if (reset_repeat) {
+        console.log('Resetting repeat');
+        res = await fetch(get_sonos_url('repeat/off'));
+        if (!res.ok)
         throw new Error(
-          `Unexpected response while turning repeat off: ${res.status}`
+            `Unexpected response while turning repeat off: ${res.status}`
         );
     } else {
-      console.log('Skipping resetting repeat setting');
+        console.log('Skipping resetting repeat');
+    }   
+    await new Promise((resolve) => setTimeout(resolve, 200));
+    
+    if (reset_shuffle) {
+        console.log('Resetting shuffle');
+        res = await fetch(get_sonos_url('shuffle/off'));
+        if (!res.ok)
+        throw new Error(
+            `Unexpected response while turning shuffle off: ${res.status}`
+        );
+    } else {
+        console.log('Skipping resetting shuffle');
     }
     await new Promise((resolve) => setTimeout(resolve, 200));
-    if (reset_shuffle == true){
-      console.log('Resetting repeat setting');
-      res = await fetch(get_sonos_url('shuffle/off'));
-      if (!res.ok)
+
+    if (reset_crossfade) {
+        console.log('Resetting crossfade');
+        res = await fetch(get_sonos_url('crossfade/off'));
+        if (!res.ok)
         throw new Error(
-          `Unexpected response while turning shuffle off: ${res.status}`
+            `Unexpected response while turning crossfade off: ${res.status}`
         );
     } else {
-      console.log('Skipping resetting shuffle setting');
+        console.log('Skipping resetting scrossfade');
     }
-    if (reset_crossfade == true){
-      console.log('Resetting crossfade setting');
-      res = await fetch(get_sonos_url('crossfade/off'));
-      if (!res.ok)
-        throw new Error(
-          `Unexpected response while turning crossfade off: ${res.status}`
-        );
-    } else {
-      console.log('Skipping resetting crossfade setting');
-    }
+    await new Promise((resolve) => setTimeout(resolve, 200));
+
     res = await fetch(get_sonos_url('clearqueue'));
+    console.log('Clearing Sonos queue');
     if (!res.ok)
       throw new Error(
         `Unexpected response while clearing queue: ${res.status}`

--- a/lib/process_sonos_command.js
+++ b/lib/process_sonos_command.js
@@ -29,10 +29,10 @@ export default async function process_sonos_command(received_text) {
   } else if (received_text_lower.startsWith('spotify:')) {
     service_type = 'spotify';
     sonos_instruction = 'spotify/now/' + received_text;
-  } else if (received_text_lower.startsWith('tunein/')) {
+  } else if (received_text_lower.startsWith('tunein')) {
     service_type = 'tunein';
     sonos_instruction = received_text;
-  } else if (received_text_lower.startsWith('favorite/')) {
+  } else if (received_text_lower.startsWith('favorite')) {
     service_type = 'favorite';
     sonos_instruction = received_text;
   } else if (received_text_lower.startsWith('amazonmusic:')) {

--- a/lib/process_sonos_command.js
+++ b/lib/process_sonos_command.js
@@ -53,7 +53,7 @@ export default async function process_sonos_command(received_text) {
   if (!service_type) {
     console.log(
       'Service type not recognised. Text should begin ' +
-        "'spotify', 'tunein', 'amazonmusic', 'apple'/'applemusic', 'command', 'http', 'playlist', or 'room'."
+        "'spotify', 'tunein', 'favorite', 'amazonmusic', 'apple'/'applemusic', 'command', 'http', 'playlist', or 'room'."
     );
     return;
   }

--- a/lib/process_sonos_command.js
+++ b/lib/process_sonos_command.js
@@ -1,7 +1,7 @@
 import fetch from 'node-fetch';
 import fs from 'fs';
 
-var { sonos_room, sonos_http_api } = JSON.parse(
+var { sonos_room, sonos_http_api, reset_shuffle, reset_repeat, reset_crossfade } = JSON.parse(
   fs.readFileSync('usersettings.json', 'utf-8')
 );
 
@@ -59,25 +59,40 @@ export default async function process_sonos_command(received_text) {
 
   if (service_type != 'command') {
     console.log(
-      'Resetting Sonos queue (clear, turn off repeat, shuffle, crossfade)'
+      'Resetting Sonos queue (clear, turn off repeat, shuffle, crossfade as per usersettings.json)'
     );
     let res;
-    res = await fetch(get_sonos_url('repeat/off'));
-    if (!res.ok)
-      throw new Error(
-        `Unexpected response while turning repeat off: ${res.status}`
-      );
+    if (reset_repeat == true) {
+      console.log('Resetting repeat setting');
+      res = await fetch(get_sonos_url('repeat/off'));
+      if (!res.ok) {
+        throw new Error(
+          `Unexpected response while turning repeat off: ${res.status}`
+        );
+    } else {
+      console.log('Skipping resetting repeat setting');
+    }
     await new Promise((resolve) => setTimeout(resolve, 200));
-    res = await fetch(get_sonos_url('shuffle/off'));
-    if (!res.ok)
-      throw new Error(
-        `Unexpected response while turning shuffle off: ${res.status}`
-      );
-    res = await fetch(get_sonos_url('crossfade/off'));
-    if (!res.ok)
-      throw new Error(
-        `Unexpected response while turning crossfade off: ${res.status}`
-      );
+    if (reset_shuffle == true){
+      console.log('Resetting repeat setting');
+      res = await fetch(get_sonos_url('shuffle/off'));
+      if (!res.ok)
+        throw new Error(
+          `Unexpected response while turning shuffle off: ${res.status}`
+        );
+    } else {
+      console.log('Skipping resetting shuffle setting');
+    }
+    if (reset_crossfade == true){
+      console.log('Resetting crossfade setting');
+      res = await fetch(get_sonos_url('crossfade/off'));
+      if (!res.ok)
+        throw new Error(
+          `Unexpected response while turning crossfade off: ${res.status}`
+        );
+    } else {
+      console.log('Skipping resetting crossfade setting');
+    }
     res = await fetch(get_sonos_url('clearqueue'));
     if (!res.ok)
       throw new Error(

--- a/lib/process_sonos_command.js
+++ b/lib/process_sonos_command.js
@@ -29,10 +29,10 @@ export default async function process_sonos_command(received_text) {
   } else if (received_text_lower.startsWith('spotify:')) {
     service_type = 'spotify';
     sonos_instruction = 'spotify/now/' + received_text;
-  } else if (received_text_lower.startsWith('tunein')) {
+  } else if (received_text_lower.startsWith('tunein/')) {
     service_type = 'tunein';
     sonos_instruction = received_text;
-  } else if (received_text_lower.startsWith('favorite')) {
+  } else if (received_text_lower.startsWith('favorite/')) {
     service_type = 'favorite';
     sonos_instruction = received_text;
   } else if (received_text_lower.startsWith('amazonmusic:')) {

--- a/usersettings.json
+++ b/usersettings.json
@@ -1,4 +1,7 @@
 {
   "sonos_http_api": "http://localhost:5005",
-  "sonos_room": "Living Room"
+  "sonos_room": "Living Room",
+  "reset_repeat": "true",
+  "reset_shuffle": "true",
+  "reset_crossfade": "true"
 }

--- a/usersettings.json
+++ b/usersettings.json
@@ -1,7 +1,7 @@
 {
   "sonos_http_api": "http://localhost:5005",
   "sonos_room": "Living Room",
-  "reset_repeat": "true",
-  "reset_shuffle": "true",
-  "reset_crossfade": "true"
+  "reset_repeat": true,
+  "reset_shuffle": true,
+  "reset_crossfade": true
 }


### PR DESCRIPTION
Pull request to implement user definable behaviour for resetting shuffle, repeat and cross-fade behaviour on starting new music.
Also adding in capability of selecting Sonos favourites by name and aligning "tunein" functionality to that within hankhank10's original vinylemulator respository.