### PR TITLE
feat:add support to store multiple commands in NFC card

### DIFF
--- a/lib/sonos_nfc.js
+++ b/lib/sonos_nfc.js
@@ -60,6 +60,13 @@ const sonos_nfc = (nfc) => {
               case 'text':
                 const received_text = record.text;
                 console.log('Read from NFC tag with message: ', received_text);
+                // splt lines to accommodate for multiple commands
+                var lines = received_text.split("\n");
+                console.log('Lines read from NFC tag: ', lines);
+
+                for (const command of lines) {
+                  await process_sonos_command(command);
+                }
 
                 await process_sonos_command(received_text);
             }


### PR DESCRIPTION
This adds support to store multiple commands in NFC card in text feld separated by line breaks, allowing things like storing a room change in a card and then playing an album from a particular track, such as:
```
room:Den
spotify:playlist:5B8etHA3kzgOZ5Pdz2FAVe
command:trackseek/2
```